### PR TITLE
Replace statik with embed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,18 @@
 all: wrp
 
-wrp: wrp.go statik
+wrp: wrp.go
 	go build wrp.go
 
-cross: statik
+cross:
 	GOOS=linux GOARCH=amd64 go build -a -o wrp-amd64-linux wrp.go
 	GOOS=freebsd GOARCH=amd64 go build -a -o wrp-amd64-freebsd wrp.go
 	GOOS=openbsd GOARCH=amd64 go build -a -o wrp-amd64-openbsd wrp.go
 	GOOS=darwin GOARCH=amd64 go build -a -o wrp-amd64-macos wrp.go
+	GOOS=darwin GOARCH=arm64 go build -a -o wrp-arm64-macos wrp.go
 	GOOS=windows GOARCH=amd64 go build -a -o wrp-amd64-windows.exe wrp.go
 	GOOS=windows GOARCH=386 go build -a -o wrp-386-windows.exe wrp.go
 	GOOS=linux GOARCH=arm go build -a -o wrp-arm-linux wrp.go
 	GOOS=linux GOARCH=arm64 go build -a -o wrp-arm64-linux wrp.go
-
-statik: wrp.html
-	go generate
 
 docker: wrp
 	docker build -t tenox7/wrp:latest .
@@ -27,4 +25,4 @@ gcrio:
 	docker push gcr.io/tenox7/wrp
 
 clean:
-	rm -rf wrp-* wrp statik
+	rm -rf wrp-* wrp

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,5 @@ require (
 	github.com/chromedp/cdproto v0.0.0-20210305224431-50b9f457e822
 	github.com/chromedp/chromedp v0.6.8
 	github.com/ericpauley/go-quantize v0.0.0-20200331213906-ae555eb2afa4
-	github.com/rakyll/statik v0.1.7
 	golang.org/x/sys v0.0.0-20210305230114-8fe3ee5dd75b // indirect
 )

--- a/wrp.go
+++ b/wrp.go
@@ -12,6 +12,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"embed"
 	"flag"
 	"fmt"
 	"html/template"
@@ -37,8 +38,6 @@ import (
 	"github.com/chromedp/cdproto/page"
 	"github.com/chromedp/chromedp"
 	"github.com/ericpauley/go-quantize/quantize"
-	"github.com/rakyll/statik/fs"
-	_ "github.com/tenox7/wrp/statik"
 )
 
 var (
@@ -53,6 +52,9 @@ var (
 	defGeom  geom
 	htmlTmpl *template.Template
 )
+
+// go:embed *.html
+var fs embed.FS
 
 type geom struct {
 	w int64
@@ -416,11 +418,7 @@ func tmpl(t string) string {
 	return string(tmpl)
 
 statik:
-	sfs, err := fs.New()
-	if err != nil {
-		log.Fatal(err)
-	}
-	fhs, err := sfs.Open("/wrp.html")
+	fhs, err := fs.Open("/wrp.html")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/wrp.go
+++ b/wrp.go
@@ -5,8 +5,6 @@
 // Copyright (c) 2019-2021 Google LLC
 //
 
-//go:generate statik -f -src=. -include=wrp.html
-
 package main
 
 import (


### PR DESCRIPTION
Fixes #93 by removing the dependency on statik and using the standard embed package instead.

While I'm here, this also adds an arm64 macOS cross compile.